### PR TITLE
chore: Upgrade to PHP 8.5

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -9,5 +9,5 @@ jobs:
   deploy:
     uses: ./.github/workflows/build-publish-docker.yml
     with:
-      image_name: "docker-pulsar-php84-test"
+      image_name: "docker-pulsar-php85-test"
       tag: "latest"

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -9,5 +9,5 @@ jobs:
   deploy:
     uses: ./.github/workflows/build-publish-docker.yml
     with:
-      image_name: "docker-pulsar-php84"
+      image_name: "docker-pulsar-php85"
       tag: "latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && \
 RUN docker-php-ext-install gmp
 
 # Install xdebug (but do not activate it)
-RUN pecl install xdebug
+RUN pecl install xdebug-3.5.0alpha3
 RUN docker-php-ext-enable xdebug
 RUN cd /usr/local/etc/php/ && mkdir -p disabled/ && mv conf.d/docker-php-ext-xdebug.ini disabled/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,9 @@ RUN apt-get update && \
 RUN docker-php-ext-install gmp
 
 # Install xdebug (but do not activate it)
-RUN pecl install xdebug-3.5.0alpha3
+RUN pecl config-set preferred_state alpha && \
+    pecl install xdebug && \
+    pecl config-set preferred_state stable
 RUN docker-php-ext-enable xdebug
 RUN cd /usr/local/etc/php/ && mkdir -p disabled/ && mv conf.d/docker-php-ext-xdebug.ini disabled/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,10 @@ RUN apt-get update && \
 RUN docker-php-ext-install gmp
 
 # Install xdebug (but do not activate it)
-RUN pecl config-set preferred_state alpha && \
-    pecl install xdebug && \
-    pecl config-set preferred_state stable
-RUN docker-php-ext-enable xdebug
-RUN cd /usr/local/etc/php/ && mkdir -p disabled/ && mv conf.d/docker-php-ext-xdebug.ini disabled/
+# Note: Will skip if no stable version available for current PHP version
+RUN pecl install xdebug || true
+RUN docker-php-ext-enable xdebug || true
+RUN cd /usr/local/etc/php/ && mkdir -p disabled/ && mv conf.d/docker-php-ext-xdebug.ini disabled/ || true
 
 # Enable apache modules
 RUN a2enmod rewrite headers expires ssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-apache-bookworm
+FROM php:8.5-apache-bookworm
 
 # Install utilities and libraries
 RUN apt-get update && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 [![Publish to ghcr](https://github.com/ophelios-studio/docker-pulsar-php84/actions/workflows/publish.yml/badge.svg)](https://github.com/ophelios-studio/docker-pulsar-php84/actions/workflows/publish.yml)
 
-# Docker Pulsar PHP 8.4
+# Docker Pulsar PHP 8.5
 
-Publication vers ghcr de l'image PHP (8.4) nécessaire pour les projets Pulsar. Pour publier une nouvelle version, 
+Publication vers ghcr de l'image PHP (8.5) nécessaire pour les projets Pulsar. Pour publier une nouvelle version,
 simplement faire un _push_ sur la branche principale.
 
 ## Définitions
 
-* PHP 8.4 (Apache-Bookworm)
+* PHP 8.5 (Apache-Bookworm)
 * Composer
 * XDebug
 * Duplicity


### PR DESCRIPTION
This PR upgrades the base image to use PHP 8.5. It will create a new image package with the new name leaving the 8.4 still available while the testing of 8.5 is done with each application.